### PR TITLE
Raise error when advisory lock cannot be acquired

### DIFF
--- a/lib/closure_tree/finders.rb
+++ b/lib/closure_tree/finders.rb
@@ -17,7 +17,7 @@ module ClosureTree
       return found if found
 
       attrs = subpath.shift
-      _ct.with_advisory_lock do
+      _ct.with_advisory_lock! do
         # shenanigans because children.create is bound to the superclass
         # (in the case of polymorphism):
         child = self.children.where(attrs).first || begin
@@ -159,7 +159,7 @@ module ClosureTree
         attr_path = _ct.build_ancestry_attr_path(path, attributes)
         find_by_path(attr_path) || begin
           root_attrs = attr_path.shift
-          _ct.with_advisory_lock do
+          _ct.with_advisory_lock! do
             # shenanigans because find_or_create can't infer that we want the same class as this:
             # Note that roots will already be constrained to this subclass (in the case of polymorphism):
             root = roots.where(root_attrs).first || _ct.create!(self, root_attrs)

--- a/lib/closure_tree/has_closure_tree.rb
+++ b/lib/closure_tree/has_closure_tree.rb
@@ -12,6 +12,7 @@ module ClosureTree
         :numeric_order,
         :touch,
         :with_advisory_lock,
+        :advisory_lock_timeout_seconds,
         :order_belong_to
       )
 

--- a/lib/closure_tree/hierarchy_maintenance.rb
+++ b/lib/closure_tree/hierarchy_maintenance.rb
@@ -53,7 +53,7 @@ module ClosureTree
     end
 
     def _ct_before_destroy
-      _ct.with_advisory_lock do
+      _ct.with_advisory_lock! do
         delete_hierarchy_references
         if _ct.options[:dependent] == :nullify
           self.class.find(self.id).children.find_each { |c| c.rebuild! }
@@ -63,7 +63,7 @@ module ClosureTree
     end
 
     def rebuild!(called_by_rebuild = false)
-      _ct.with_advisory_lock do
+      _ct.with_advisory_lock! do
         delete_hierarchy_references unless (defined? @was_new_record) && @was_new_record
         hierarchy_class.create!(:ancestor => self, :descendant => self, :generations => 0)
         unless root?
@@ -89,7 +89,7 @@ module ClosureTree
     end
 
     def delete_hierarchy_references
-      _ct.with_advisory_lock do
+      _ct.with_advisory_lock! do
         # The crazy double-wrapped sub-subselect works around MySQL's limitation of subselects on the same table that is being mutated.
         # It shouldn't affect performance of postgresql.
         # See http://dev.mysql.com/doc/refman/5.0/en/subquery-errors.html
@@ -111,7 +111,7 @@ module ClosureTree
       # Rebuilds the hierarchy table based on the parent_id column in the database.
       # Note that the hierarchy table will be truncated.
       def rebuild!
-        _ct.with_advisory_lock do
+        _ct.with_advisory_lock! do
           cleanup!
           roots.find_each { |n| n.send(:rebuild!) } # roots just uses the parent_id column, so this is safe.
         end

--- a/lib/closure_tree/numeric_deterministic_ordering.rb
+++ b/lib/closure_tree/numeric_deterministic_ordering.rb
@@ -125,7 +125,7 @@ module ClosureTree
       # Make sure self isn't dirty, because we're going to call reload:
       save
 
-      _ct.with_advisory_lock do
+      _ct.with_advisory_lock! do
         prior_sibling_parent = sibling.parent
         reorder_from_value = if prior_sibling_parent == self.parent
           [self.order_value, sibling.order_value].compact.min

--- a/lib/closure_tree/support.rb
+++ b/lib/closure_tree/support.rb
@@ -23,7 +23,7 @@ module ClosureTree
         :dependent => :nullify, # or :destroy or :delete_all -- see the README
         :name_column => 'name',
         :with_advisory_lock => true,
-        :advisory_lock_timeout_seconds => 5,
+        :advisory_lock_timeout_seconds => 15,
         :numeric_order => false
       }.merge(options)
       raise ArgumentError, "name_column can't be 'path'" if options[:name_column] == 'path'

--- a/lib/closure_tree/support.rb
+++ b/lib/closure_tree/support.rb
@@ -23,13 +23,10 @@ module ClosureTree
         :dependent => :nullify, # or :destroy or :delete_all -- see the README
         :name_column => 'name',
         :with_advisory_lock => true,
-        :advisory_lock_timeout_seconds => nil,
+        :advisory_lock_timeout_seconds => 5,
         :numeric_order => false
       }.merge(options)
       raise ArgumentError, "name_column can't be 'path'" if options[:name_column] == 'path'
-      if !options[:with_advisory_lock] && options[:advisory_lock_timeout_seconds].present?
-        raise ArgumentError, "advisory_lock_timeout_seconds cannot be provided when advisory lock is disabled"
-      end
       if order_is_numeric?
         extend NumericOrderSupport.adapter_for_connection(connection)
       end

--- a/lib/closure_tree/support.rb
+++ b/lib/closure_tree/support.rb
@@ -23,6 +23,7 @@ module ClosureTree
         :dependent => :nullify, # or :destroy or :delete_all -- see the README
         :name_column => 'name',
         :with_advisory_lock => true,
+        :advisory_lock_timeout_seconds => nil,
         :numeric_order => false
       }.merge(options)
       raise ArgumentError, "name_column can't be 'path'" if options[:name_column] == 'path'
@@ -108,9 +109,10 @@ module ClosureTree
       end
     end
 
-    def with_advisory_lock(&block)
+    def with_advisory_lock!(&block)
       if options[:with_advisory_lock]
-        model_class.with_advisory_lock!(advisory_lock_name, timeout_seconds: 5) do
+        lock_options = { timeout_seconds: options[:advisory_lock_timeout_seconds] }.compact
+        model_class.with_advisory_lock!(advisory_lock_name, lock_options) do
           transaction { yield }
         end
       else

--- a/lib/closure_tree/support.rb
+++ b/lib/closure_tree/support.rb
@@ -27,6 +27,9 @@ module ClosureTree
         :numeric_order => false
       }.merge(options)
       raise ArgumentError, "name_column can't be 'path'" if options[:name_column] == 'path'
+      if !options[:with_advisory_lock] && options[:advisory_lock_timeout_seconds].present?
+        raise ArgumentError, "advisory_lock_timeout_seconds cannot be provided when advisory lock is disabled"
+      end
       if order_is_numeric?
         extend NumericOrderSupport.adapter_for_connection(connection)
       end

--- a/lib/closure_tree/support.rb
+++ b/lib/closure_tree/support.rb
@@ -114,8 +114,7 @@ module ClosureTree
 
     def with_advisory_lock!(&block)
       if options[:with_advisory_lock]
-        lock_options = { timeout_seconds: options[:advisory_lock_timeout_seconds] }.compact
-        model_class.with_advisory_lock!(advisory_lock_name, lock_options) do
+        model_class.with_advisory_lock!(advisory_lock_name, advisory_lock_options) do
           transaction { yield }
         end
       else

--- a/lib/closure_tree/support.rb
+++ b/lib/closure_tree/support.rb
@@ -110,7 +110,7 @@ module ClosureTree
 
     def with_advisory_lock(&block)
       if options[:with_advisory_lock]
-        model_class.with_advisory_lock(advisory_lock_name) do
+        model_class.with_advisory_lock!(advisory_lock_name, timeout_seconds: 5) do
           transaction { yield }
         end
       else

--- a/lib/closure_tree/support_attributes.rb
+++ b/lib/closure_tree/support_attributes.rb
@@ -8,6 +8,10 @@ module ClosureTree
       Digest::SHA1.hexdigest("ClosureTree::#{base_class.name}")[0..32]
     end
 
+    def advisory_lock_options
+      { timeout_seconds: options[:advisory_lock_timeout_seconds] }.compact
+    end
+
     def quoted_table_name
       connection.quote_table_name(table_name)
     end

--- a/spec/closure_tree/parallel_spec.rb
+++ b/spec/closure_tree/parallel_spec.rb
@@ -121,12 +121,6 @@ RSpec.describe 'Concurrent creation' do
   end
 
   it 'fails to deadlock while simultaneously deleting items from the same hierarchy' do
-    allow(User).to receive(:with_advisory_lock!).and_wrap_original do |method, *args, &block|
-      options = args.extract_options!
-      options[:timeout_seconds] = 15
-      method.call(*args, options, &block)
-    end
-
     target = User.find_or_create_by_path((1..200).to_a.map { |ea| ea.to_s })
     emails = target.self_and_ancestors.to_a.map(&:email).shuffle
     Parallel.map(emails, :in_threads => max_threads) do |email|

--- a/spec/closure_tree/parallel_spec.rb
+++ b/spec/closure_tree/parallel_spec.rb
@@ -121,6 +121,12 @@ RSpec.describe 'Concurrent creation' do
   end
 
   it 'fails to deadlock while simultaneously deleting items from the same hierarchy' do
+    allow(User).to receive(:with_advisory_lock!).and_wrap_original do |method, *args, &block|
+      options = args.extract_options!
+      options[:timeout_seconds] = nil
+      method.call(*args, options, &block)
+    end
+
     target = User.find_or_create_by_path((1..200).to_a.map { |ea| ea.to_s })
     emails = target.self_and_ancestors.to_a.map(&:email).shuffle
     Parallel.map(emails, :in_threads => max_threads) do |email|

--- a/spec/closure_tree/parallel_spec.rb
+++ b/spec/closure_tree/parallel_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe 'Concurrent creation' do
 
   it 'creates dupe roots without advisory locks' do
     # disable with_advisory_lock:
-    allow(Tag).to receive(:with_advisory_lock) { |_lock_name, &block| block.call }
+    allow(Tag).to receive(:with_advisory_lock!) { |_lock_name, &block| block.call }
     run_workers
     # duplication from at least one iteration:
     expect(Tag.where(name: @names).size).to be > @iterations

--- a/spec/closure_tree/parallel_spec.rb
+++ b/spec/closure_tree/parallel_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe 'Concurrent creation' do
   it 'fails to deadlock while simultaneously deleting items from the same hierarchy' do
     allow(User).to receive(:with_advisory_lock!).and_wrap_original do |method, *args, &block|
       options = args.extract_options!
-      options[:timeout_seconds] = nil
+      options[:timeout_seconds] = 15
       method.call(*args, options, &block)
     end
 

--- a/spec/closure_tree/support_spec.rb
+++ b/spec/closure_tree/support_spec.rb
@@ -1,14 +1,38 @@
 require 'spec_helper'
 
 RSpec.describe ClosureTree::Support do
-  let(:sut) { Tag._ct }
+  let(:model) { Tag }
+  let(:options) { {} }
+  let(:sut) { described_class.new(model, options) }
+
   it 'passes through table names without prefix and suffix' do
     expected = 'some_random_table_name'
     expect(sut.remove_prefix_and_suffix(expected)).to eq(expected)
   end
+
   it 'extracts through table name with prefix and suffix' do
     expected = 'some_random_table_name'
     tn = ActiveRecord::Base.table_name_prefix + expected + ActiveRecord::Base.table_name_suffix
     expect(sut.remove_prefix_and_suffix(tn)).to eq(expected)
+  end
+
+  [
+    [true, 10, { timeout_seconds: 10 }],
+    [true, nil, {}],
+    [false, nil, {}]
+  ].each do |with_lock, timeout, expected_options|
+    context "when with_advisory_lock is #{with_lock} and timeout is #{timeout}" do
+      let(:options) { { with_advisory_lock: with_lock, advisory_lock_timeout_seconds: timeout } }
+
+      it "uses advisory lock with timeout options: #{expected_options}" do
+        if with_lock
+          expect(model).to receive(:with_advisory_lock!).with(anything, expected_options).and_yield
+        else
+          expect(model).not_to receive(:with_advisory_lock!)
+        end
+
+        expect { |b| sut.with_advisory_lock!(&b) }.to yield_control
+      end
+    end
   end
 end


### PR DESCRIPTION
Gitlab Issue: https://gitlab.com/jklabsinc/OpsLevel/-/issues/13122

I found traces where jobs fail with a lock timeout after 50s when inserting into `entity_node_hierarchy` so that means our jobs do fail if the actual insert is taking long.

But there are traces ([example](https://app.datadoghq.com/apm/entity/service%3Aopslevel-sidekiq?dependencyMap=qson%3A%28data%3A%28telemetrySelection%3Aall_sources%29%2Cversion%3A%210%29&deployments=qson%3A%28data%3A%28hits%3A%28selected%3Aversion_count%29%2Cerrors%3A%28selected%3Aversion_count%29%2Clatency%3A%28selected%3Ap95%29%2CtopN%3A%215%29%2Cversion%3A%210%29&env=production&fromUser=false&graphType=flamegraph&groupMapByOperation=null&infrastructure=qson%3A%28data%3A%28viewType%3Aresources%29%2Cversion%3A%210%29&operationName=sidekiq.job&panels=qson%3A%28data%3A%28activePanelKey%3Atrace%2Cresource%3A%28resourceName%3ARelationship%253A%253ACreateOrDestroyEntityEdgeFromTagWorker%2CresourceID%3Ad05c73ffb51fba4b%29%2Ctrace%3A%28traceID%3A3150255045765278513%2CspanID%3A2664978902095975363%29%29%2Cversion%3A%210%29&resourceMapPrefs=qson%3A%28data%3A%28threshold%3A%210.1%29%2Cversion%3A%210%29&resources=qson%3A%28data%3A%28visible%3A%21t%2Chits%3A%28selected%3Atotal%29%2Cerrors%3A%28selected%3Atotal%29%2Clatency%3A%28selected%3Ap95%29%2CtopN%3A%215%2Csearch%3Adestroy%29%2Cversion%3A%211%29&shouldShowLegend=true&sort=time&spanID=2664978902095975363&spanViewType=metadata&summary=qson%3A%28data%3A%28visible%3A%21t%2Cchanges%3A%28%29%2Cerrors%3A%28selected%3Acount%29%2Chits%3A%28selected%3Acount%29%2Clatency%3A%28selected%3Alatency%2Cslot%3A%28agg%3A95%29%2Cdistribution%3A%28isLogScale%3A%21f%29%2CshowTraceOutliers%3A%21t%29%2Csublayer%3A%28slot%3A%28layers%3AserviceAndInferred%29%2Cselected%3Apercentage%29%2ClagMetrics%3A%28selectedMetric%3A%21s%2CselectedGroupBy%3A%21s%29%29%2Cversion%3A%211%29&timeHint=1741355477539&trace=AwAAAZVw3-ojRGPq7gAAABhBWlZ3My0zQ0FBQUtXR3Q1TmduUnVyY3IAAAAkMDE5NTcxNDYtOWY3MC00NGZkLTlkMTQtZjdhMDA3Yzc2ZWU5AAS18Q&traceID=3150255045765278513&traces=qson%3A%28data%3A%28%29%2Cversion%3A%210%29&start=1741352400000&end=1741356000000&paused=true)) where the job sits for minutes just doing `SELECT GET_LOCK` until it gets shutdown by sidekiq. The `SELECT GET_LOCK` comes from the closure_tree gem and the gem always calls `with_advisory_lock` without any options which means that it waits indefinitely for the lock.

So this MR uses `with_advisory_lock!` so that it raises an error if we can't get the lock instead of just waiting indefinitely so that the jobs will end up in the dead set if there's a lot of contention. https://github.com/ClosureTree/with_advisory_lock/blob/master/lib/with_advisory_lock/concern.rb#L16